### PR TITLE
Create leasing pricing matrix

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "zod": "^4.0.17"
   },
   "devDependencies": {
+    "@eslint/eslintrc": "^3.3.1",
     "@playwright/test": "1.54.1",
     "@testing-library/react": "16.3.0",
     "@types/node": "^22.5.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
         specifier: ^4.0.17
         version: 4.0.17
     devDependencies:
+      '@eslint/eslintrc':
+        specifier: ^3.3.1
+        version: 3.3.1
       '@playwright/test':
         specifier: 1.54.1
         version: 1.54.1

--- a/src/collections/Cars.ts
+++ b/src/collections/Cars.ts
@@ -490,6 +490,74 @@ export const Cars: CollectionConfig = {
                                 },
                                 {
                                     type: 'array',
+                                    name: 'pricing_matrix',
+                                    label: 'Árazási mátrix',
+                                    admin: {
+                                        description: 'Futamidő, önerő és éves futás kombinációk havi díjjal és maradványértékkel.'
+                                    },
+                                    labels: {
+                                        singular: 'Árkombináció',
+                                        plural: 'Árkombinációk'
+                                    },
+                                    fields: [
+                                        {
+                                            type: 'row',
+                                            fields: [
+                                                {
+                                                    type: 'select',
+                                                    name: 'term_months',
+                                                    label: 'Futamidő (hónap)',
+                                                    required: true,
+                                                    options: [
+                                                        { label: '36', value: '36' },
+                                                        { label: '48', value: '48' },
+                                                    ],
+                                                },
+                                                {
+                                                    type: 'select',
+                                                    name: 'down_payment_percent',
+                                                    label: 'Önerő (%)',
+                                                    required: true,
+                                                    options: [
+                                                        { label: '10%', value: '10' },
+                                                        { label: '20%', value: '20' },
+                                                    ],
+                                                },
+                                                {
+                                                    type: 'select',
+                                                    name: 'annual_mileage_km',
+                                                    label: 'Éves futás (km)',
+                                                    required: true,
+                                                    options: [
+                                                        { label: '20 000', value: '20000' },
+                                                        { label: '30 000', value: '30000' },
+                                                    ],
+                                                },
+                                            ]
+                                        },
+                                        {
+                                            type: 'row',
+                                            fields: [
+                                                {
+                                                    type: 'number',
+                                                    name: 'monthly_fee',
+                                                    label: 'Havi díj (HUF)',
+                                                    required: true,
+                                                    min: 0,
+                                                },
+                                                {
+                                                    type: 'number',
+                                                    name: 'residual_value',
+                                                    label: 'Maradványérték (HUF)',
+                                                    required: true,
+                                                    min: 0,
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    type: 'array',
                                     name: 'benefits',
                                     label: 'Termék előnyök',
                                     labels: {

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -233,6 +233,19 @@ export interface Car {
     lease?: {
       is_leasable?: boolean | null;
       lease_price_per_month?: string | null;
+      /**
+       * Futamidő, önerő és éves futás kombinációk havi díjjal és maradványértékkel.
+       */
+      pricing_matrix?:
+        | {
+            term_months: '36' | '48';
+            down_payment_percent: '10' | '20';
+            annual_mileage_km: '20000' | '30000';
+            monthly_fee: number;
+            residual_value: number;
+            id?: string | null;
+          }[]
+        | null;
       benefits?:
         | {
             icon?: (number | null) | Media;
@@ -449,6 +462,16 @@ export interface CarsSelect<T extends boolean = true> {
           | {
               is_leasable?: T;
               lease_price_per_month?: T;
+              pricing_matrix?:
+                | T
+                | {
+                    term_months?: T;
+                    down_payment_percent?: T;
+                    annual_mileage_km?: T;
+                    monthly_fee?: T;
+                    residual_value?: T;
+                    id?: T;
+                  };
               benefits?:
                 | T
                 | {


### PR DESCRIPTION
Add a leasing pricing matrix to the Car collection to allow admin users to define monthly fees and residual values based on lease term, down payment, and annual mileage.

The initial implementation supports a subset of options (36/48 months, 10/20% down, 20k/30k km) as requested, with the schema designed for easy expansion to other options (24/60 months, 0/30% down, 40k km) in the future.

---
<a href="https://cursor.com/background-agent?bcId=bc-bd041c01-c883-4b0e-9c51-153bbeec0fd9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bd041c01-c883-4b0e-9c51-153bbeec0fd9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

